### PR TITLE
Add project repository and version control module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # deepevents.ai
 deepevents.ai main codebase
+
+## Modules
+
+- [Project Repository and Version Control](project-repository-version-control/README.md)

--- a/project-repository-version-control/README.md
+++ b/project-repository-version-control/README.md
@@ -1,0 +1,70 @@
+# Project Repository and Version Control
+
+Self-contained MVP module for issue #10. It models scientific project repositories with structured sections, typed artifacts, commits, diffs, forks, merge requests, reproducibility checks, citation metadata, and archive manifests.
+
+## Capabilities
+
+- Creates repositories with required scientific sections: manuscript, data, code, notebooks, results, protocols, and metadata.
+- Validates typed artifacts and ensures files live inside expected repository sections.
+- Creates commit records with parent links, artifact manifests, timestamps, and manifest hashes.
+- Computes commit diffs for added, modified, and removed scientific artifacts.
+- Creates forks and merge requests with mergeability signals.
+- Runs reproducibility checks for data, code/notebooks, metadata, and manifest integrity.
+- Emits schema.org citation metadata for repository releases.
+- Exports archive manifests for reproducible downloads or long-term preservation.
+
+## Usage
+
+```bash
+cd project-repository-version-control
+npm test
+```
+
+```js
+import {
+  createProjectRepository,
+  createArtifact,
+  createCommit,
+  runReproducibilityChecks,
+} from "./src/repository.js";
+
+const repository = createProjectRepository({
+  repository_id: "repo_1",
+  title: "Catalyst Study",
+  owner_id: "user_1",
+});
+
+const artifact = createArtifact({
+  artifact_id: "data_1",
+  path: "data/measurements.csv",
+  type: "csv",
+  content: "sample,value\nA,1\n",
+});
+
+const commit = createCommit({
+  commit_id: "commit_1",
+  author_id: "user_1",
+  message: "Add dataset",
+  artifacts: [artifact],
+});
+
+console.log(repository);
+console.log(runReproducibilityChecks(commit));
+```
+
+## Requirement Mapping
+
+| Issue requirement | Implementation |
+| --- | --- |
+| Scientific project structure | `createProjectRepository()` enforces manuscript, data, code, notebooks, results, protocols, and metadata sections. |
+| Artifact storage | `createArtifact()` validates file type, section path, content hash, size, and metadata. |
+| Version control | `createCommit()` records parent commit IDs, artifact manifests, timestamps, and manifest hashes. |
+| Diffs | `diffCommits()` reports added, modified, and removed files. |
+| Forks | `createFork()` models repository forks from a source commit. |
+| Merge requests | `createMergeRequest()` records source/target commits, diffs, status, and mergeability. |
+| Reproducibility checks | `runReproducibilityChecks()` verifies data, code/notebook, metadata, and manifest presence. |
+| Citations and exports | `createCitationMetadata()` and `exportRepositoryArchive()` emit schema.org citation data and archive manifests. |
+
+## Verification
+
+The test suite covers repository structure, artifact validation, commits, diffs, forks, merge requests, reproducibility checks, citation metadata, and archive exports.

--- a/project-repository-version-control/package.json
+++ b/project-repository-version-control/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@scibase/project-repository-version-control",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/project-repository-version-control/src/repository.js
+++ b/project-repository-version-control/src/repository.js
@@ -1,0 +1,186 @@
+const REQUIRED_SECTIONS = ["manuscript", "data", "code", "notebooks", "results", "protocols", "metadata"]
+const ALLOWED_FILE_TYPES = new Set([
+  "markdown",
+  "latex",
+  "csv",
+  "tsv",
+  "json",
+  "parquet",
+  "python",
+  "r",
+  "julia",
+  "notebook",
+  "image",
+  "model",
+  "protocol",
+])
+
+function requireString(value, field) {
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`${field} is required`)
+  return value.trim()
+}
+
+function hashContent(content) {
+  let hash = 0
+  for (let i = 0; i < content.length; i += 1) {
+    hash = (hash * 31 + content.charCodeAt(i)) >>> 0
+  }
+  return hash.toString(16).padStart(8, "0")
+}
+
+export function createProjectRepository({
+  repository_id,
+  title,
+  owner_id,
+  visibility = "private",
+  license = "CC-BY-4.0",
+  sections = REQUIRED_SECTIONS,
+}) {
+  const normalizedSections = [...new Set(sections.map((section) => requireString(section, "section")))]
+  const missing = REQUIRED_SECTIONS.filter((section) => !normalizedSections.includes(section))
+  if (missing.length > 0) throw new Error(`Missing required repository sections: ${missing.join(", ")}`)
+  return {
+    repository_id: requireString(repository_id, "repository_id"),
+    title: requireString(title, "title"),
+    owner_id: requireString(owner_id, "owner_id"),
+    visibility,
+    license,
+    sections: normalizedSections.map((section) => ({ name: section, path: `${section}/` })),
+    branches: [{ name: "main", head_commit_id: null }],
+  }
+}
+
+export function createArtifact({ artifact_id, path, type, content, metadata = {} }) {
+  if (!ALLOWED_FILE_TYPES.has(type)) throw new Error(`Unsupported artifact type: ${type}`)
+  const normalizedPath = requireString(path, "path").replace(/\\/g, "/")
+  const topLevel = normalizedPath.split("/")[0]
+  if (!REQUIRED_SECTIONS.includes(topLevel)) throw new Error(`Artifact path must live under a repository section: ${topLevel}`)
+  return {
+    artifact_id: requireString(artifact_id, "artifact_id"),
+    path: normalizedPath,
+    type,
+    content_hash: hashContent(requireString(content, "content")),
+    bytes: Buffer.byteLength(content),
+    metadata,
+  }
+}
+
+export function createCommit({
+  commit_id,
+  parent_commit_id = null,
+  author_id,
+  message,
+  artifacts = [],
+  created_at = new Date().toISOString(),
+}) {
+  return {
+    commit_id: requireString(commit_id, "commit_id"),
+    parent_commit_id,
+    author_id: requireString(author_id, "author_id"),
+    message: requireString(message, "message"),
+    artifacts,
+    created_at,
+    manifest_hash: hashContent(JSON.stringify(artifacts.map((artifact) => [artifact.path, artifact.content_hash]).sort())),
+  }
+}
+
+export function diffCommits(baseCommit, headCommit) {
+  const base = new Map(baseCommit.artifacts.map((artifact) => [artifact.path, artifact]))
+  const head = new Map(headCommit.artifacts.map((artifact) => [artifact.path, artifact]))
+  const added = []
+  const modified = []
+  const removed = []
+
+  for (const [path, artifact] of head) {
+    if (!base.has(path)) added.push(path)
+    else if (base.get(path).content_hash !== artifact.content_hash) modified.push(path)
+  }
+  for (const path of base.keys()) {
+    if (!head.has(path)) removed.push(path)
+  }
+
+  return { added, modified, removed }
+}
+
+export function createFork({ source_repository_id, fork_repository_id, owner_id, source_commit_id }) {
+  return {
+    repository_id: requireString(fork_repository_id, "fork_repository_id"),
+    forked_from: requireString(source_repository_id, "source_repository_id"),
+    owner_id: requireString(owner_id, "owner_id"),
+    branches: [{ name: "main", head_commit_id: requireString(source_commit_id, "source_commit_id") }],
+  }
+}
+
+export function createMergeRequest({
+  merge_request_id,
+  source_repository_id,
+  target_repository_id,
+  source_commit,
+  target_commit,
+  title,
+  author_id,
+}) {
+  const diff = diffCommits(target_commit, source_commit)
+  return {
+    merge_request_id: requireString(merge_request_id, "merge_request_id"),
+    source_repository_id: requireString(source_repository_id, "source_repository_id"),
+    target_repository_id: requireString(target_repository_id, "target_repository_id"),
+    title: requireString(title, "title"),
+    author_id: requireString(author_id, "author_id"),
+    source_commit_id: source_commit.commit_id,
+    target_commit_id: target_commit.commit_id,
+    diff,
+    status: "open",
+    mergeable: diff.removed.length === 0,
+  }
+}
+
+export function runReproducibilityChecks(commit) {
+  const paths = new Set(commit.artifacts.map((artifact) => artifact.path))
+  const hasData = [...paths].some((path) => path.startsWith("data/"))
+  const hasCode = [...paths].some((path) => path.startsWith("code/") || path.startsWith("notebooks/"))
+  const hasMetadata = [...paths].some((path) => path.startsWith("metadata/"))
+  return {
+    commit_id: commit.commit_id,
+    checks: [
+      { name: "data-present", passed: hasData },
+      { name: "code-or-notebook-present", passed: hasCode },
+      { name: "metadata-present", passed: hasMetadata },
+      { name: "manifest-hash-present", passed: Boolean(commit.manifest_hash) },
+    ],
+    passed: hasData && hasCode && hasMetadata && Boolean(commit.manifest_hash),
+  }
+}
+
+export function createCitationMetadata({ repository, commit, doi = null, authors = [], keywords = [] }) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ScholarlyArticle",
+    identifier: doi ?? `${repository.repository_id}:${commit.commit_id}`,
+    name: repository.title,
+    version: commit.commit_id,
+    license: repository.license,
+    author: authors.map((author) => ({ "@type": "Person", name: requireString(author, "author") })),
+    keywords,
+    hasPart: commit.artifacts.map((artifact) => ({
+      "@type": "CreativeWork",
+      name: artifact.path,
+      encodingFormat: artifact.type,
+      sha256: artifact.content_hash,
+    })),
+  }
+}
+
+export function exportRepositoryArchive({ repository, commit }) {
+  return {
+    repository_id: repository.repository_id,
+    commit_id: commit.commit_id,
+    manifest_hash: commit.manifest_hash,
+    files: commit.artifacts.map((artifact) => ({
+      path: artifact.path,
+      type: artifact.type,
+      bytes: artifact.bytes,
+      content_hash: artifact.content_hash,
+    })),
+  }
+}

--- a/project-repository-version-control/test/repository.test.js
+++ b/project-repository-version-control/test/repository.test.js
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  createArtifact,
+  createCitationMetadata,
+  createCommit,
+  createFork,
+  createMergeRequest,
+  createProjectRepository,
+  diffCommits,
+  exportRepositoryArchive,
+  runReproducibilityChecks,
+} from "../src/repository.js"
+
+test("creates repositories with required scientific sections", () => {
+  const repo = createProjectRepository({
+    repository_id: "repo_1",
+    title: "Catalyst Study",
+    owner_id: "user_1",
+  })
+
+  assert.deepEqual(
+    repo.sections.map((section) => section.name),
+    ["manuscript", "data", "code", "notebooks", "results", "protocols", "metadata"],
+  )
+  assert.throws(
+    () => createProjectRepository({ repository_id: "bad", title: "Bad", owner_id: "u", sections: ["data"] }),
+    /Missing required repository sections/,
+  )
+})
+
+test("creates typed artifacts inside repository sections", () => {
+  const artifact = createArtifact({
+    artifact_id: "artifact_1",
+    path: "data/measurements.csv",
+    type: "csv",
+    content: "sample,value\nA,1\n",
+    metadata: { rows: 1 },
+  })
+
+  assert.equal(artifact.path, "data/measurements.csv")
+  assert.equal(artifact.bytes, 17)
+  assert.throws(
+    () => createArtifact({ artifact_id: "bad", path: "tmp/file.txt", type: "markdown", content: "x" }),
+    /repository section/,
+  )
+})
+
+test("creates commits and diffs scientific artifacts", () => {
+  const dataV1 = createArtifact({ artifact_id: "data_1", path: "data/a.csv", type: "csv", content: "a\n1\n" })
+  const codeV1 = createArtifact({ artifact_id: "code_1", path: "code/analyze.py", type: "python", content: "print(1)" })
+  const dataV2 = createArtifact({ artifact_id: "data_1", path: "data/a.csv", type: "csv", content: "a\n2\n" })
+  const meta = createArtifact({ artifact_id: "meta_1", path: "metadata/schema.json", type: "json", content: "{}" })
+  const base = createCommit({ commit_id: "c1", author_id: "u", message: "initial", artifacts: [dataV1, codeV1] })
+  const head = createCommit({ commit_id: "c2", parent_commit_id: "c1", author_id: "u", message: "update", artifacts: [dataV2, codeV1, meta] })
+
+  assert.notEqual(base.manifest_hash, head.manifest_hash)
+  assert.deepEqual(diffCommits(base, head), {
+    added: ["metadata/schema.json"],
+    modified: ["data/a.csv"],
+    removed: [],
+  })
+})
+
+test("creates forks and merge requests with mergeability signals", () => {
+  const data = createArtifact({ artifact_id: "data", path: "data/a.csv", type: "csv", content: "a\n1\n" })
+  const code = createArtifact({ artifact_id: "code", path: "code/a.py", type: "python", content: "print(1)" })
+  const base = createCommit({ commit_id: "c1", author_id: "u1", message: "base", artifacts: [data] })
+  const head = createCommit({ commit_id: "c2", author_id: "u2", message: "add code", artifacts: [data, code] })
+  const fork = createFork({
+    source_repository_id: "repo_1",
+    fork_repository_id: "repo_2",
+    owner_id: "u2",
+    source_commit_id: "c1",
+  })
+  const mr = createMergeRequest({
+    merge_request_id: "mr_1",
+    source_repository_id: fork.repository_id,
+    target_repository_id: "repo_1",
+    source_commit: head,
+    target_commit: base,
+    title: "Add analysis script",
+    author_id: "u2",
+  })
+
+  assert.equal(fork.forked_from, "repo_1")
+  assert.equal(mr.mergeable, true)
+  assert.deepEqual(mr.diff.added, ["code/a.py"])
+})
+
+test("runs reproducibility checks and exports citation/archive metadata", () => {
+  const repo = createProjectRepository({ repository_id: "repo_1", title: "Catalyst Study", owner_id: "u" })
+  const artifacts = [
+    createArtifact({ artifact_id: "d", path: "data/a.csv", type: "csv", content: "a\n1\n" }),
+    createArtifact({ artifact_id: "c", path: "notebooks/analysis.ipynb", type: "notebook", content: "{}" }),
+    createArtifact({ artifact_id: "m", path: "metadata/schema.json", type: "json", content: "{}" }),
+  ]
+  const commit = createCommit({ commit_id: "c1", author_id: "u", message: "reproducible release", artifacts })
+  const checks = runReproducibilityChecks(commit)
+  const citation = createCitationMetadata({
+    repository: repo,
+    commit,
+    doi: "10.1234/scibase.repo",
+    authors: ["Ada Lovelace"],
+    keywords: ["catalyst"],
+  })
+  const archive = exportRepositoryArchive({ repository: repo, commit })
+
+  assert.equal(checks.passed, true)
+  assert.equal(citation.identifier, "10.1234/scibase.repo")
+  assert.equal(citation.hasPart.length, 3)
+  assert.equal(archive.files[0].path, "data/a.csv")
+})


### PR DESCRIPTION
## Summary

Adds a self-contained project repository and version control MVP module for issue #10.

Covers scientific repository sections, typed artifacts, commits, diffs, forks, merge requests, reproducibility checks, citation metadata, and archive manifests.

/claim #10

## Verification

```bash
cd project-repository-version-control
npm test
```