### PR TITLE
Add reproducible scientific artifact capsules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # deepevents.ai
 deepevents.ai main codebase
+
+## SCIBASE research modules
+
+- [Scientific Data & Code Hosting Capsule](scientific-data-code-hosting/README.md): dependency-free artifact manifest, FAIR metadata, version diff, metadata export, and execution-readiness milestone for issue #14.

--- a/scientific-data-code-hosting/DEMO.md
+++ b/scientific-data-code-hosting/DEMO.md
@@ -1,0 +1,41 @@
+# Reviewer Demo
+
+This demo is text-first so reviewers can verify the implementation without
+installing screen-recording tools or third-party packages.
+
+## Command
+
+```bash
+python scientific-data-code-hosting/demo.py
+```
+
+## Expected Output Summary
+
+```text
+SCIBASE FAIR artifact capsule demo contains 2 artifacts, FAIR score 1.00, execution ready.
+```
+
+The demo then prints a schema.org JSON-LD `Dataset` export with:
+
+- `@id`: `10.0000/scibase-demo-capsule`
+- `name`: `SCIBASE FAIR artifact capsule demo`
+- `creator`: `SCIBASE reviewer`
+- `hasPart`: one Python analysis file and one CSV measurement dataset
+- SHA-256 hashes for both artifacts
+
+## What The Demo Proves
+
+- The capsule builder can scan a nested project folder.
+- Dataset and code artifacts are classified correctly.
+- CSV metadata previews are generated.
+- Environment readiness detects `requirements.txt`.
+- FAIR scoring reaches 1.00 when required metadata is present.
+- JSON-LD metadata can be emitted without external APIs.
+
+## Test Command
+
+```bash
+python -m unittest discover scientific-data-code-hosting -v
+```
+
+Current local result: 7 tests passed.

--- a/scientific-data-code-hosting/README.md
+++ b/scientific-data-code-hosting/README.md
@@ -28,6 +28,7 @@ to executable environment readiness.
   environment readiness checks, and dataset diff logic.
 - `demo.py` - creates a temporary sample project and prints a manifest summary
   plus JSON-LD export.
+- `DEMO.md` - reviewer-facing command transcript and proof checklist.
 - `test_artifact_capsule.py` - unittest coverage for classification, manifests,
   metadata exports, FAIR findings, diffs, summaries, and invalid JSON previews.
 

--- a/scientific-data-code-hosting/README.md
+++ b/scientific-data-code-hosting/README.md
@@ -1,0 +1,59 @@
+# Scientific Data & Code Hosting Capsule
+
+This is a dependency-free milestone for SCIBASE issue #14. It models a
+reviewable "artifact capsule" for scientific data/code hosting: every file gets
+typed, hashed, previewed, checked against FAIR metadata expectations, and linked
+to executable environment readiness.
+
+## What It Covers
+
+- Scalable storage primitives: folder-aware artifact manifests for datasets,
+  code, supplementary files, and model files.
+- Metadata-aware previews: CSV/TSV table summaries, JSON validity/key summaries,
+  code line counts, and media preview flags.
+- Versioning and diffing: content hashes for immutable versions plus a tabular
+  diff helper for dataset row changes.
+- Structured metadata exports: JSON-LD, DataCite-style metadata, and schema.org
+  dataset distribution payloads.
+- FAIR checks: findable, accessible, interoperable, and reusable checks with a
+  reviewer-readable score and findings.
+- Executable environments: detection of Dockerfile, environment.yml,
+  requirements.txt, or pyproject.toml, plus recommendations when missing.
+- Compute triggers: manual run, reproduce-results, and scheduled refresh command
+  plans.
+
+## Files
+
+- `artifact_capsule.py` - core capsule builder, FAIR checker, metadata exporters,
+  environment readiness checks, and dataset diff logic.
+- `demo.py` - creates a temporary sample project and prints a manifest summary
+  plus JSON-LD export.
+- `test_artifact_capsule.py` - unittest coverage for classification, manifests,
+  metadata exports, FAIR findings, diffs, summaries, and invalid JSON previews.
+
+## Run Locally
+
+```bash
+python scientific-data-code-hosting/demo.py
+python -m unittest discover scientific-data-code-hosting -v
+```
+
+## Requirement Mapping
+
+| Issue #14 requirement | This milestone |
+| --- | --- |
+| Support major file types | Classifies datasets, code, media, model, and supplementary files by extension. |
+| Folder organization | Builds relative logical paths from nested project folders. |
+| Metadata previews | Generates table, JSON, code, media, and binary preview records. |
+| Upload versioning/diffing | Stores SHA-256 version records and includes a tabular diff helper. |
+| JSON-LD/DataCite/schema.org | `build_metadata_exports()` emits all three payload shapes. |
+| FAIR compliance | `evaluate_fair_compliance()` scores findable/access/interoperable/reusable checks. |
+| Executable environments | `check_environment_readiness()` detects Dockerfile/env/requirements definitions. |
+| Reproduce buttons/triggers | `plan_compute_triggers()` defines run-analysis, reproduce-results, and scheduled-refresh commands. |
+
+## Review Notes
+
+The module is deterministic and does not call external services. It does not
+require credentials, cloud storage, Docker daemon access, payment accounts, or
+private data. It is designed as a safe first implementation layer that can later
+be wired into real upload, DOI, storage, and execution services.

--- a/scientific-data-code-hosting/artifact_capsule.py
+++ b/scientific-data-code-hosting/artifact_capsule.py
@@ -1,0 +1,335 @@
+"""Reproducible scientific artifact capsules.
+
+This module is intentionally dependency-free so reviewers can run it in a bare
+Python environment. It models the core data/code hosting primitives requested in
+issue #14: artifact manifests, FAIR checks, metadata exports, version diffs, and
+executable environment readiness.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DATA_EXTENSIONS = {".csv", ".tsv", ".json", ".xlsx", ".parquet"}
+CODE_EXTENSIONS = {".py", ".r", ".jl", ".ipynb"}
+MEDIA_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".mp4", ".mov"}
+MODEL_EXTENSIONS = {".pkl", ".joblib", ".pt", ".pth", ".onnx", ".h5"}
+ENVIRONMENT_FILES = {
+    "Dockerfile",
+    "environment.yml",
+    "environment.yaml",
+    "requirements.txt",
+    "pyproject.toml",
+}
+
+
+@dataclass(frozen=True)
+class ArtifactVersion:
+    version: str
+    path: str
+    artifact_type: str
+    media_type: str
+    sha256: str
+    size_bytes: int
+    preview: dict[str, Any]
+    created_at: str
+
+
+@dataclass
+class ArtifactRecord:
+    logical_path: str
+    tags: list[str] = field(default_factory=list)
+    versions: list[ArtifactVersion] = field(default_factory=list)
+
+    @property
+    def latest(self) -> ArtifactVersion:
+        if not self.versions:
+            raise ValueError(f"artifact {self.logical_path!r} has no versions")
+        return self.versions[-1]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def classify_artifact(path: Path) -> tuple[str, str]:
+    suffix = path.suffix.lower()
+    if suffix in DATA_EXTENSIONS:
+        return "dataset", _media_type_for_suffix(suffix)
+    if suffix in CODE_EXTENSIONS:
+        return "code", _media_type_for_suffix(suffix)
+    if suffix in MEDIA_EXTENSIONS:
+        return "supplementary", _media_type_for_suffix(suffix)
+    if suffix in MODEL_EXTENSIONS:
+        return "model", "application/octet-stream"
+    return "supplementary", "application/octet-stream"
+
+
+def _media_type_for_suffix(suffix: str) -> str:
+    return {
+        ".csv": "text/csv",
+        ".tsv": "text/tab-separated-values",
+        ".json": "application/json",
+        ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ".parquet": "application/vnd.apache.parquet",
+        ".py": "text/x-python",
+        ".r": "text/x-r",
+        ".jl": "text/x-julia",
+        ".ipynb": "application/x-ipynb+json",
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".svg": "image/svg+xml",
+        ".mp4": "video/mp4",
+        ".mov": "video/quicktime",
+    }.get(suffix, "application/octet-stream")
+
+
+def build_artifact_version(path: Path, root: Path, version: str = "v1") -> ArtifactVersion:
+    content = path.read_bytes()
+    artifact_type, media_type = classify_artifact(path)
+    return ArtifactVersion(
+        version=version,
+        path=path.relative_to(root).as_posix(),
+        artifact_type=artifact_type,
+        media_type=media_type,
+        sha256=sha256_bytes(content),
+        size_bytes=len(content),
+        preview=preview_artifact(path, content),
+        created_at=utc_now(),
+    )
+
+
+def preview_artifact(path: Path, content: bytes) -> dict[str, Any]:
+    suffix = path.suffix.lower()
+    if suffix in {".csv", ".tsv"}:
+        delimiter = "\t" if suffix == ".tsv" else ","
+        text = content.decode("utf-8", errors="replace")
+        rows = list(csv.reader(text.splitlines(), delimiter=delimiter))
+        headers = rows[0] if rows else []
+        return {
+            "kind": "table",
+            "headers": headers,
+            "row_count": max(len(rows) - 1, 0),
+            "column_count": len(headers),
+            "sample_rows": rows[1:4],
+        }
+    if suffix == ".json":
+        try:
+            data = json.loads(content.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            return {"kind": "json", "valid": False, "error": str(exc)}
+        return {
+            "kind": "json",
+            "valid": True,
+            "top_level": type(data).__name__,
+            "keys": sorted(data.keys())[:10] if isinstance(data, dict) else [],
+        }
+    if suffix in CODE_EXTENSIONS:
+        text = content.decode("utf-8", errors="replace")
+        return {
+            "kind": "code",
+            "line_count": len(text.splitlines()),
+            "entrypoint_hint": "main" in text or "__main__" in text,
+        }
+    if suffix in MEDIA_EXTENSIONS:
+        return {"kind": "media", "thumbnail_ready": suffix != ".mp4"}
+    return {"kind": "binary", "preview_available": False}
+
+
+def build_capsule_manifest(
+    root: Path,
+    metadata: dict[str, Any],
+    *,
+    tags_by_path: dict[str, list[str]] | None = None,
+) -> dict[str, Any]:
+    tags_by_path = tags_by_path or {}
+    files = [
+        path
+        for path in root.rglob("*")
+        if path.is_file() and ".git" not in path.parts and path.name not in ENVIRONMENT_FILES
+    ]
+    artifacts: list[ArtifactRecord] = []
+    for file_path in sorted(files):
+        relative_path = file_path.relative_to(root).as_posix()
+        artifacts.append(
+            ArtifactRecord(
+                logical_path=relative_path,
+                tags=tags_by_path.get(relative_path, []),
+                versions=[build_artifact_version(file_path, root)],
+            )
+        )
+
+    manifest = {
+        "schema": "scibase.reproducible-artifact-capsule.v1",
+        "generated_at": utc_now(),
+        "metadata": metadata,
+        "artifacts": [_artifact_to_dict(artifact) for artifact in artifacts],
+        "environment": check_environment_readiness(root),
+        "compute_triggers": plan_compute_triggers(metadata),
+    }
+    manifest["fair"] = evaluate_fair_compliance(manifest)
+    return manifest
+
+
+def _artifact_to_dict(record: ArtifactRecord) -> dict[str, Any]:
+    return {
+        "logical_path": record.logical_path,
+        "tags": record.tags,
+        "versions": [version.__dict__ for version in record.versions],
+    }
+
+
+def evaluate_fair_compliance(manifest: dict[str, Any]) -> dict[str, Any]:
+    metadata = manifest.get("metadata", {})
+    artifacts = manifest.get("artifacts", [])
+    checks = {
+        "findable": bool(metadata.get("identifier") and metadata.get("title")),
+        "accessible": bool(metadata.get("access") and metadata.get("license")),
+        "interoperable": all(
+            "sha256" in artifact["versions"][-1] and "media_type" in artifact["versions"][-1]
+            for artifact in artifacts
+        ),
+        "reusable": bool(metadata.get("license") and metadata.get("creators") and artifacts),
+    }
+    findings = []
+    for key, passed in checks.items():
+        if not passed:
+            findings.append(f"{key} requirement is incomplete")
+
+    score = round(sum(1 for passed in checks.values() if passed) / len(checks), 2)
+    return {"score": score, "checks": checks, "findings": findings}
+
+
+def check_environment_readiness(root: Path) -> dict[str, Any]:
+    present = sorted(file_name for file_name in ENVIRONMENT_FILES if (root / file_name).exists())
+    runtime = "container" if "Dockerfile" in present else "language-environment"
+    ready = bool(present)
+    recommendations = []
+    if not present:
+        recommendations.append("Add Dockerfile, environment.yml, requirements.txt, or pyproject.toml")
+    if "Dockerfile" not in present:
+        recommendations.append("Add Dockerfile for one-click reproducible execution")
+    return {
+        "ready": ready,
+        "runtime": runtime if ready else "unknown",
+        "definition_files": present,
+        "recommendations": recommendations,
+    }
+
+
+def plan_compute_triggers(metadata: dict[str, Any]) -> list[dict[str, str]]:
+    base_command = metadata.get("reproduce_command", "python analysis.py")
+    return [
+        {
+            "name": "run-analysis",
+            "kind": "manual",
+            "command": base_command,
+            "purpose": "Run the main analysis once from the capsule environment.",
+        },
+        {
+            "name": "reproduce-results",
+            "kind": "review",
+            "command": metadata.get("reproduce_command", base_command),
+            "purpose": "Re-run the documented workflow during review or publication checks.",
+        },
+        {
+            "name": "scheduled-refresh",
+            "kind": "cron",
+            "command": metadata.get("refresh_command", base_command),
+            "purpose": "Refresh derived outputs for periodically updated datasets.",
+        },
+    ]
+
+
+def diff_tabular_versions(old_content: str, new_content: str, delimiter: str = ",") -> dict[str, Any]:
+    old_rows = list(csv.reader(old_content.splitlines(), delimiter=delimiter))
+    new_rows = list(csv.reader(new_content.splitlines(), delimiter=delimiter))
+    old_header = old_rows[0] if old_rows else []
+    new_header = new_rows[0] if new_rows else []
+    old_body = {tuple(row) for row in old_rows[1:]}
+    new_body = {tuple(row) for row in new_rows[1:]}
+    return {
+        "kind": "table-diff",
+        "headers_changed": old_header != new_header,
+        "old_row_count": len(old_rows[1:]),
+        "new_row_count": len(new_rows[1:]),
+        "rows_added": len(new_body - old_body),
+        "rows_removed": len(old_body - new_body),
+    }
+
+
+def build_metadata_exports(manifest: dict[str, Any]) -> dict[str, Any]:
+    metadata = manifest["metadata"]
+    artifacts = manifest["artifacts"]
+    creators = metadata.get("creators", [])
+    identifier = metadata.get("identifier", "local-capsule")
+    keywords = metadata.get("keywords", [])
+    title = metadata.get("title", "Untitled scientific artifact capsule")
+    description = metadata.get("description", "")
+
+    json_ld = {
+        "@context": "https://schema.org",
+        "@type": "Dataset",
+        "@id": identifier,
+        "name": title,
+        "description": description,
+        "keywords": keywords,
+        "license": metadata.get("license"),
+        "creator": [{"@type": "Person", "name": creator} for creator in creators],
+        "hasPart": [
+            {
+                "@type": "DigitalDocument",
+                "name": artifact["logical_path"],
+                "encodingFormat": artifact["versions"][-1]["media_type"],
+                "sha256": artifact["versions"][-1]["sha256"],
+            }
+            for artifact in artifacts
+        ],
+    }
+    datacite = {
+        "identifier": {"identifier": identifier, "identifierType": "DOI" if identifier.startswith("10.") else "UUID"},
+        "creators": [{"name": creator} for creator in creators],
+        "titles": [{"title": title}],
+        "publisher": metadata.get("publisher", "SCIBASE.AI"),
+        "publicationYear": metadata.get("publication_year", datetime.now(timezone.utc).year),
+        "types": {"resourceTypeGeneral": "Dataset"},
+        "descriptions": [{"description": description, "descriptionType": "Abstract"}],
+        "subjects": [{"subject": keyword} for keyword in keywords],
+    }
+    schema_org = {
+        "type": "Dataset",
+        "name": title,
+        "identifier": identifier,
+        "isAccessibleForFree": metadata.get("access", "public") == "public",
+        "distribution": [
+            {
+                "contentUrl": artifact["logical_path"],
+                "encodingFormat": artifact["versions"][-1]["media_type"],
+            }
+            for artifact in artifacts
+        ],
+    }
+    return {"json_ld": json_ld, "datacite": datacite, "schema_org": schema_org}
+
+
+def summarize_capsule(manifest: dict[str, Any]) -> str:
+    artifacts = manifest["artifacts"]
+    fair = manifest["fair"]
+    ready = "ready" if manifest["environment"]["ready"] else "needs environment"
+    return (
+        f"{manifest['metadata'].get('title', 'Capsule')} contains {len(artifacts)} artifacts, "
+        f"FAIR score {fair['score']:.2f}, execution {ready}."
+    )

--- a/scientific-data-code-hosting/demo.py
+++ b/scientific-data-code-hosting/demo.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from artifact_capsule import build_capsule_manifest, build_metadata_exports, summarize_capsule
+
+
+def create_demo_project(root: Path) -> None:
+    (root / "data").mkdir()
+    (root / "analysis").mkdir()
+    (root / "data" / "measurements.csv").write_text(
+        "sample,temperature_c,signal\nA,21.2,0.84\nB,22.0,0.91\n",
+        encoding="utf-8",
+    )
+    (root / "analysis" / "analysis.py").write_text(
+        "print('Reproducing SCIBASE demo analysis')\n",
+        encoding="utf-8",
+    )
+    (root / "requirements.txt").write_text("numpy>=1.26\npandas>=2.2\n", encoding="utf-8")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        create_demo_project(root)
+        manifest = build_capsule_manifest(
+            root,
+            {
+                "identifier": "10.0000/scibase-demo-capsule",
+                "title": "SCIBASE FAIR artifact capsule demo",
+                "description": "Small reproducible data/code package for issue #14 review.",
+                "creators": ["SCIBASE reviewer"],
+                "keywords": ["FAIR", "reproducibility", "data hosting"],
+                "license": "MIT",
+                "access": "public",
+                "reproduce_command": "python analysis/analysis.py",
+            },
+            tags_by_path={"data/measurements.csv": ["temperature", "instrument-output"]},
+        )
+        exports = build_metadata_exports(manifest)
+        print(summarize_capsule(manifest))
+        print(json.dumps(exports["json_ld"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scientific-data-code-hosting/test_artifact_capsule.py
+++ b/scientific-data-code-hosting/test_artifact_capsule.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from artifact_capsule import (
+    build_capsule_manifest,
+    build_metadata_exports,
+    classify_artifact,
+    diff_tabular_versions,
+    summarize_capsule,
+)
+
+
+class ArtifactCapsuleTests(unittest.TestCase):
+    def make_project(self) -> Path:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        root = Path(temp_dir.name)
+        (root / "data").mkdir()
+        (root / "notebooks").mkdir()
+        (root / "data" / "observations.csv").write_text(
+            "id,value\nobs-1,4.2\nobs-2,5.1\n",
+            encoding="utf-8",
+        )
+        (root / "notebooks" / "reproduce.py").write_text(
+            "def main():\n    return 'ok'\n",
+            encoding="utf-8",
+        )
+        (root / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+        return root
+
+    def metadata(self) -> dict[str, object]:
+        return {
+            "identifier": "10.1234/scibase.capsule",
+            "title": "Reproducible sensor study",
+            "description": "A tiny reproducible capsule used by tests.",
+            "creators": ["Ada Lovelace", "Grace Hopper"],
+            "keywords": ["sensor", "FAIR"],
+            "license": "MIT",
+            "access": "public",
+            "reproduce_command": "python notebooks/reproduce.py",
+        }
+
+    def test_classifies_data_and_code_files(self) -> None:
+        self.assertEqual(classify_artifact(Path("table.csv")), ("dataset", "text/csv"))
+        self.assertEqual(classify_artifact(Path("workflow.py")), ("code", "text/x-python"))
+
+    def test_build_manifest_hashes_artifacts_and_scores_fair(self) -> None:
+        root = self.make_project()
+        manifest = build_capsule_manifest(root, self.metadata())
+        self.assertEqual(manifest["schema"], "scibase.reproducible-artifact-capsule.v1")
+        self.assertEqual(len(manifest["artifacts"]), 2)
+        self.assertEqual(manifest["fair"]["score"], 1.0)
+        self.assertTrue(manifest["environment"]["ready"])
+        first_version = manifest["artifacts"][0]["versions"][0]
+        self.assertEqual(len(first_version["sha256"]), 64)
+
+    def test_metadata_exports_include_artifact_distribution(self) -> None:
+        manifest = build_capsule_manifest(self.make_project(), self.metadata())
+        exports = build_metadata_exports(manifest)
+        self.assertEqual(exports["json_ld"]["@type"], "Dataset")
+        self.assertEqual(exports["datacite"]["identifier"]["identifierType"], "DOI")
+        self.assertEqual(len(exports["schema_org"]["distribution"]), 2)
+
+    def test_fair_findings_report_missing_metadata(self) -> None:
+        manifest = build_capsule_manifest(self.make_project(), {"title": "Partial"})
+        findings = manifest["fair"]["findings"]
+        self.assertLess(manifest["fair"]["score"], 1.0)
+        self.assertIn("accessible requirement is incomplete", findings)
+
+    def test_tabular_diff_counts_added_and_removed_rows(self) -> None:
+        old_csv = "id,value\nobs-1,4.2\nobs-2,5.1\n"
+        new_csv = "id,value\nobs-2,5.1\nobs-3,7.3\n"
+        diff = diff_tabular_versions(old_csv, new_csv)
+        self.assertEqual(diff["rows_added"], 1)
+        self.assertEqual(diff["rows_removed"], 1)
+        self.assertFalse(diff["headers_changed"])
+
+    def test_summary_is_reviewer_readable(self) -> None:
+        manifest = build_capsule_manifest(self.make_project(), self.metadata())
+        summary = summarize_capsule(manifest)
+        self.assertIn("Reproducible sensor study", summary)
+        self.assertIn("FAIR score 1.00", summary)
+
+    def test_json_preview_marks_invalid_json(self) -> None:
+        root = self.make_project()
+        (root / "data" / "broken.json").write_text("{bad json", encoding="utf-8")
+        manifest = build_capsule_manifest(root, self.metadata())
+        json_artifact = next(a for a in manifest["artifacts"] if a["logical_path"] == "data/broken.json")
+        self.assertFalse(json_artifact["versions"][0]["preview"]["valid"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #14

## Summary
- Adds a dependency-free reproducible artifact capsule module for scientific data/code hosting.
- Builds folder-aware artifact manifests with SHA-256 hashes, file classification, metadata previews, FAIR scoring, environment readiness, and compute trigger plans.
- Exports JSON-LD, DataCite-style metadata, and schema.org dataset distribution payloads.
- Includes a demo script, reviewer demo transcript, requirement mapping README, and unittest coverage.

## Validation
- `py -m unittest discover scientific-data-code-hosting -v` (7 tests passed)
- `py scientific-data-code-hosting\demo.py`
- `py -m py_compile scientific-data-code-hosting\artifact_capsule.py scientific-data-code-hosting\demo.py scientific-data-code-hosting\test_artifact_capsule.py`
- `git diff --check`

## Reviewer demo
- See `scientific-data-code-hosting/DEMO.md` for the command transcript and proof checklist.

## Notes
- No credentials, cloud accounts, private data, or external services are required.
- The implementation is intentionally self-contained so reviewers can run it in a bare Python environment.